### PR TITLE
feat: add Tab+Enter restart functionality during typing test

### DIFF
--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -18,6 +18,7 @@ type Model struct {
 	finalStats  game.TypingStats
 	duration    int
 	language    string
+	tabPressed  bool
 }
 
 // tickMsg is a message type used to handle periodic updates in the application
@@ -41,6 +42,7 @@ func (m *Model) restartTest() {
 	m.game = game.NewTypingGame(m.duration)
 	m.showResults = false
 	m.finalStats = game.TypingStats{}
+	m.tabPressed = false
 }
 
 // Init initializes the model and starts the tick command for periodic updates

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -19,7 +19,20 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case "ctrl+c", "esc":
 			return m, tea.Quit
 
+		case "tab":
+			// Track Tab key press
+			m.tabPressed = true
+			return m, nil
+
 		case "enter":
+			// Check for Tab+Enter combination to restart during test
+			if m.tabPressed && !m.showResults && m.game.IsStarted {
+				m.restartTest()
+				return m, tickCmd()
+			}
+			// Reset Tab state after Enter
+			m.tabPressed = false
+
 			if m.showResults {
 				m.restartTest()
 				return m, tickCmd()
@@ -31,18 +44,24 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 
 		case " ":
+			// Reset Tab state on any other key
+			m.tabPressed = false
 			if !m.showResults && !m.game.IsFinished && !m.game.IsTimeUp() {
 				m.game.AddCharacter(' ')
 			}
 			return m, nil
 
 		case "backspace":
+			// Reset Tab state on any other key
+			m.tabPressed = false
 			if !m.showResults && !m.game.IsFinished {
 				m.game.RemoveCharacter()
 			}
 			return m, nil
 
 		default:
+			// Reset Tab state on any other key
+			m.tabPressed = false
 			// Handle regular character input
 			if !m.showResults && !m.game.IsFinished && !m.game.IsTimeUp() {
 				runes := []rune(msg.String())


### PR DESCRIPTION
Adds the ability to restart a typing test mid-session using Tab+Enter key combination, similar to Monkeytype's behavior.